### PR TITLE
added support for non default ports

### DIFF
--- a/lib/Utils.py
+++ b/lib/Utils.py
@@ -77,6 +77,8 @@ class Utils:
             u_parser = urlparse(url)
             if u_parser.scheme == 'https':
                 port = 443
+            if u_parser.port is not None:
+                port = u_parser.port
 
             host = u_parser.hostname
             parser["host"] = host


### PR DESCRIPTION
Current version ignores the explicitly specified port and replaces it with either 80 or 443 based on protocol, this commit fixes this behavior and the program will correctly use the custom port when specified.